### PR TITLE
Adjusted color scheme with reference to skin.arctic.zephyr.rounded

### DIFF
--- a/colors/Dark with Dark Dialogs.xml
+++ b/colors/Dark with Dark Dialogs.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <colors>
-    <color name="Dark1">ffd6d6d6</color>
-    <color name="Dark2">b3d6d6d6</color>
-    <color name="Dark3">4dd6d6d6</color>
-    <color name="Dark4">1fd6d6d6</color>
+    <color name="Dark1">FFC5C5C5</color>
+    <color name="Dark2">CCC5C5C5</color>
+    <color name="Dark3">4DC5C5C5</color>
+    <color name="Dark4">E62D2E2E</color>
     <color name="Light1">ff333333</color>
     <color name="Light2">b3333333</color>
     <color name="Light3">4d333333</color>
@@ -19,16 +19,24 @@
     <color name="Black30">4Dbbbbbb</color>
     <color name="Black12">1Fbbbbbb</color>
     
-    <color name="InfoBackground">b3181818</color>
+    <color name="InfoBackground">B3050505</color>
     
-    <color name="Background">ff181818</color>
+    <color name="Panel">FF2D2E2E</color>
+    <color name="PanelWhite100">FFDDDDDD</color>
+    <color name="PanelWhite90">E6DDDDDD</color>
+    <color name="PanelWhite70">B3DDDDDD</color>
+    <color name="PanelWhite30">4DDDDDDD</color>
+    <color name="PanelWhite12">1FDDDDDD</color>
+    <color name="PanelBlack30">4D000000</color>
+    
+    <color name="Background">FF050505</color>
     <color name="FanartFade">FFffffff</color>
-    <color name="FloorFade">CC181818</color>
+    <color name="FloorFade">FF181818</color>
     
-    <color name="Box2">FFA7A7A7</color>
-    <color name="BoxNotification">CCA7A7A7</color>
-    <color name="BoxWidget">FFA7A7A7</color>
-    <color name="BoxHomerow">80A7A7A7</color> 
+    <color name="Box2">FF404040</color>
+    <color name="BoxNotification">CC404040</color>
+    <color name="BoxWidget">FF404040</color>
+    <color name="BoxHomerow">80404040</color> 
     
-    <color name="Fallback">ff333333</color>
+    <color name="Fallback">FF2D2E2E</color>
 </colors>

--- a/colors/Dark with Light Dialogs.xml
+++ b/colors/Dark with Light Dialogs.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <colors>
-    <color name="Dark1">ffd6d6d6</color>
-    <color name="Dark2">b3d6d6d6</color>
-    <color name="Dark3">4dd6d6d6</color>
-    <color name="Dark4">1fd6d6d6</color>
+    <color name="Dark1">FFD6D6D6</color>
+    <color name="Dark2">CCD6D6D6</color>
+    <color name="Dark3">4DD6D6D6</color>
+    <color name="Dark4">E61B1715</color>
     <color name="Light1">ff333333</color>
     <color name="Light2">b3333333</color>
     <color name="Light3">4d333333</color>
@@ -19,16 +19,23 @@
     <color name="Black30">4D000000</color>
     <color name="Black12">1F000000</color>
 
-    <color name="InfoBackground">b3181818</color>
+    <color name="InfoBackground">B3241D18</color>
     
-    <color name="Background">ff181818</color>
+    <color name="Panel">FFD4D4D4</color>
+    <color name="PanelWhite100">B3141414</color>
+    <color name="PanelWhite90">E6DDDDDD</color>
+    <color name="PanelWhite70">B3141414</color>
+    <color name="PanelWhite30">4DDDDDDD</color>
+    <color name="PanelWhite12">4D141414</color>
+    <color name="PanelBlack30">4D000000</color>
+    
+    <color name="Background">FF241D18</color>
     <color name="FanartFade">FFffffff</color>
-    <color name="FloorFade">CC181818</color>
+    <color name="FloorFade">CC241D18</color>
     
     <color name="Box2">FFA7A7A7</color>
     <color name="BoxNotification">CCA7A7A7</color>
     <color name="BoxWidget">FFA7A7A7</color>
     <color name="BoxHomerow">80A7A7A7</color> 
     
-    <color name="Fallback">ff333333</color>
-</colors>
+    <color name="Fallback">FF141312</color>

--- a/colors/Light with Dark Dialogs.xml
+++ b/colors/Light with Dark Dialogs.xml
@@ -1,34 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <colors>
-    <color name="Dark1">ff303030</color>
+    <color name="Dark1">ff141414</color>
     <color name="Dark2">b3141414</color>
     <color name="Dark3">4d141414</color>
     <color name="Dark4">1f141414</color>
-    <color name="Light1">ffdddddd</color>
-    <color name="Light2">b3dddddd</color>
-    <color name="Light3">4ddddddd</color>
-    <color name="Light4">1fdddddd</color>
+    <color name="Light1">FFDDDDDD</color>
+    <color name="Light2">B3DDDDDD</color>
+    <color name="Light3">4DDDDDDD</color>
+    <color name="Light4">1FDDDDDD</color>
 
-    <color name="Black100">FFbbbbbb</color>
-    <color name="Black70">B3bbbbbb</color>
-    <color name="Black30">4Dbbbbbb</color>
-    <color name="Black12">1Fbbbbbb</color>
+    <color name="Black100">FFBBBBBB</color>
+    <color name="Black70">B3BBBBBB</color>
+    <color name="Black30">4DBBBBBB</color>
+    <color name="Black12">1FBBBBBB</color>
 
     <color name="White100">FF333333</color>
     <color name="White70">B3333333</color>
     <color name="White30">4D333333</color>
     <color name="White12">1F333333</color>
 
-    <color name="InfoBackground">b3ffffff</color>
+    <color name="InfoBackground">B3050505</color>
     
-    <color name="Background">ffdddddd</color>
+    <color name="Panel">FF2D2E2E</color>
+    <color name="PanelWhite100">FFDDDDDD</color>
+    <color name="PanelWhite90">E6DDDDDD</color>
+    <color name="PanelWhite70">B3DDDDDD</color>
+    <color name="PanelWhite30">4DDDDDDD</color>
+    <color name="PanelWhite12">1FDDDDDD</color>
+    <color name="PanelBlack30">4D000000</color>
+    
+    <color name="Background">FFF0F0F0</color>
     <color name="FanartFade">FFffffff</color>
-    <color name="FloorFade">BBdddddd</color>
+    <color name="FloorFade">EEF0F0F0</color>
     
-    <color name="Box2">E6888888</color>
-    <color name="BoxNotification">CC888888</color>
-    <color name="BoxWidget">E6888888</color>
-    <color name="BoxHomerow">80888888</color>
+    <color name="Box2">FF404040</color>
+    <color name="BoxNotification">CC404040</color>
+    <color name="BoxWidget">FF404040</color>
+    <color name="BoxHomerow">80404040</color>
     
-    <color name="Fallback">ff181818</color>
+    <color name="Fallback">FF2D2E2E</color>
 </colors>

--- a/colors/Light with Light Dialogs.xml
+++ b/colors/Light with Light Dialogs.xml
@@ -20,6 +20,14 @@
     <color name="Black12">1F000000</color>
 
     <color name="InfoBackground">b3ffffff</color>
+    
+    <color name="Panel">FFD4D4D4</color>
+    <color name="PanelWhite100">B3141414</color>
+    <color name="PanelWhite90">E6DDDDDD</color>
+    <color name="PanelWhite70">B3141414</color>
+    <color name="PanelWhite30">4DDDDDDD</color>
+    <color name="PanelWhite12">4D141414</color>
+    <color name="PanelBlack30">4D000000</color>
 
     <color name="Background">ffdddddd</color>
     <color name="FanartFade">FFffffff</color>

--- a/colors/defaults.xml
+++ b/colors/defaults.xml
@@ -4,24 +4,24 @@
     <color name="Highlight2">FFff4081</color>
     <color name="Selected">FFededed</color>
 
-    <color name="Dark1">ffd6d6d6</color>
-    <color name="Dark2">b3d6d6d6</color>
-    <color name="Dark3">4dd6d6d6</color>
-    <color name="Dark4">1fd6d6d6</color>
+    <color name="Dark1">FFC5C5C5</color>
+    <color name="Dark2">CCC5C5C5</color>
+    <color name="Dark3">4DC5C5C5</color>
+    <color name="Dark4">E62D2E2E</color>
     <color name="Light1">ff333333</color>
     <color name="Light2">b3333333</color>
     <color name="Light3">4d333333</color>
     <color name="Light4">1f333333</color>
 
-    <color name="White100">FFcccccc</color>
-    <color name="White70">B3cccccc</color>
-    <color name="White30">4Dcccccc</color>
-    <color name="White12">1Fcccccc</color>
+    <color name="White100">FF333333</color>
+    <color name="White70">B3333333</color>
+    <color name="White30">4D333333</color>
+    <color name="White12">1F333333</color>
 
-    <color name="Black100">FF000000</color>
-    <color name="Black70">B3000000</color>
-    <color name="Black30">4D000000</color>
-    <color name="Black12">1F000000</color>
+    <color name="Black100">FFBBBBBB</color>
+    <color name="Black70">B3BBBBBB</color>
+    <color name="Black30">4DBBBBBB</color>
+    <color name="Black12">1FBBBBBB</color>
 
     <color name="PanelWhite100">FFdddddd</color>
     <color name="PanelWhite90">E6dddddd</color>
@@ -30,22 +30,22 @@
     <color name="PanelWhite12">1Fdddddd</color>
     <color name="PanelBlack30">4D000000</color>
     
-    <color name="Panel">ff333333</color>
+    <color name="Panel">FF2D2E2E</color>
     <color name="OSDBack">df000000</color>
     <color name="OSDProgressBarColor">0Dffffff</color>
 
-    <color name="InfoBackground">b3181818</color>
+    <color name="InfoBackground">B3181818</color>
             
-    <color name="Background">ff181818</color>
+    <color name="Background">FF181818</color>
     <color name="FanartFade">FFffffff</color>
-    <color name="FloorFade">CC181818</color>
+    <color name="FloorFade">FF181818</color>
 
     <color name="WatchedProgress">ff08de4b</color>
 
-    <color name="Box2">FFA7A7A7</color>
-    <color name="BoxNotification">CCA7A7A7</color>
-    <color name="BoxWidget">FFA7A7A7</color>
-    <color name="BoxHomerow">80A7A7A7</color> 
+    <color name="Box2">E6202020</color>
+    <color name="BoxNotification">CC202020</color>
+    <color name="BoxWidget">E6202020</color>
+    <color name="BoxHomerow">80202020</color> 
     
-    <color name="Fallback">ff333333</color>    
+    <color name="Fallback">FF2D2E2E</color>
 </colors>


### PR DESCRIPTION
- Modified five color configuration files
- Added missing Panel-related color definitions
- Adjusted color scheme with reference to skin.arctic.zephyr.rounded

The color configuration file Light with Light Dialogs.xml lacks color definitions related to Panels. The settings dialog (Settings.xml) uses Panel colors for backgrounds, alongside shades such as PanelWhite100, PanelWhite70, PanelWhite30, PanelWhite12, and PanelBlack30 for text and borders.

When these colors are undefined, the system inherits the dark theme definitions from defaults.xml, resulting in dialog boxes rendering with dark backgrounds.